### PR TITLE
BugFix 0859642

### DIFF
--- a/github/info.json
+++ b/github/info.json
@@ -24,7 +24,7 @@
       },
       {
         "title": "Personal Access Token",
-        "required": false,
+        "required": true,
         "editable": true,
         "visible": true,
         "type": "password",


### PR DESCRIPTION
Personal Access Token field is not shown mandatory, but when kept empty, connector config fails to connect