### PR TITLE
Renamed `Commit Message` parameter to `Commit Summary` and added `Commit Description` parameter

### DIFF
--- a/github/info.json
+++ b/github/info.json
@@ -6,7 +6,7 @@
   "cs_approved": true,
   "cs_compatible": true,
   "version": "1.1.1",
-  "category": "Source Code Management",
+  "category": "Source Control",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
   "help_online": "",
@@ -3239,14 +3239,24 @@
           "description": "Specify the name of the branch to which you want to push the code of the local repository"
         },
         {
-          "title": "Commit Message",
+          "title": "Commit Summary",
           "name": "commit_message",
           "visible": true,
           "required": true,
           "editable": true,
           "type": "text",
-          "tooltip": "Specify the commit message to be used for pushing changes to GitHub. If you do not specify any commit message, a default commit message is used",
-          "description": "Specify the commit message to be used for pushing changes to GitHub. If you do not specify any commit message, a default commit message is used"
+          "tooltip": "Specify the commit summary to be used for pushing changes to GitHub.",
+          "description": "Specify the commit summary to be used for pushing changes to GitHub."
+        },
+        {
+          "title": "Commit Description",
+          "name": "commit_description",
+          "visible": true,
+          "required": false,
+          "editable": true,
+          "type": "text",
+          "tooltip": "Specify the commit description to be used for pushing changes to GitHub.",
+          "description": "Specify the commit description to be used for pushing changes to GitHub."
         }
       ]
     },

--- a/github/info.json
+++ b/github/info.json
@@ -6,7 +6,7 @@
   "cs_approved": true,
   "cs_compatible": true,
   "version": "1.1.1",
-  "category": "Source Control",
+  "category": "Source Code Management",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
   "help_online": "",
@@ -3254,7 +3254,7 @@
           "visible": true,
           "required": false,
           "editable": true,
-          "type": "text",
+          "type": "textarea",
           "tooltip": "Specify the commit description to be used for pushing changes to GitHub.",
           "description": "Specify the commit description to be used for pushing changes to GitHub."
         }

--- a/github/operations.py
+++ b/github/operations.py
@@ -346,6 +346,9 @@ def push_repository(config, params, *args, **kwargs):
             if not any(x in os.path.join(root, f) for x in ['.DS_Store', '.git']):
                 file_list.append(os.path.join(root, f))
     commit_message = params.get('commit_message')
+    commit_description = params.pop('commit_description', '')
+    if commit_description:
+        commit_message += '\n' + commit_description
     master_ref = repo.get_git_ref('heads/' + params.get('branch'))
     master_sha = master_ref.object.sha
     base_tree = repo.get_git_tree(master_sha)

--- a/github/release_notes.md
+++ b/github/release_notes.md
@@ -4,6 +4,7 @@
   - List Fork Repositories
   - Fork Organization Repository
 - Updated type `Comment` parameter text to richtext in `Create Issue Comment` action.
+- Renamed `Commit Message` parameter to `Commit Summary` and added `Commit Description` parameter in `Push Changes` action.
 - Updated output schema of `List Pull Request` action.
 ### What's Fixed
 - Fixed a connector health check where it should fail for invalid `Username`.


### PR DESCRIPTION
#### Changes:
- Renamed `Commit Message` parameter to `Commit Summary` and added `Commit Description` parameter in `Push Changes` action.
- Updated release notes.

#### UTCs:
- [x] Tested and verified push changes action. 