### PR TITLE
First Commit

### DIFF
--- a/github/connector.py
+++ b/github/connector.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2024 Fortinet Inc
+Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
 

--- a/github/constants.py
+++ b/github/constants.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2024 Fortinet Inc
+Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
 

--- a/github/constants.py
+++ b/github/constants.py
@@ -7,3 +7,5 @@ Copyright end
 
 CLONE_ACCEPT_HEADER = {
     'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'}
+
+CLONE_URL = "https://codeload.github.com"

--- a/github/info.json
+++ b/github/info.json
@@ -5,23 +5,53 @@
   "publisher": "Fortinet",
   "cs_approved": true,
   "cs_compatible": true,
-  "version": "1.3.0",
+  "version": "2.0.0",
   "category": "Source Code Management",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.3.0/github/897/github-v1-3-0",
+  "help_online": "",
   "configuration": {
     "fields": [
       {
-        "title": "Server API URL",
+        "title": "GitHub Account",
         "required": true,
         "editable": true,
         "visible": true,
-        "type": "text",
-        "name": "server_url",
-        "value": "https://api.github.com",
-        "description": "Specify the URL of the GitHub server to connect and perform automated operations.",
-        "tooltip": "Specify the URL of the GitHub server to connect and perform automated operations"
+        "type": "select",
+        "name": "github_account",
+        "description": "Select the option used to access the GitHub server to connect and perform the automated operations.",
+        "tooltip": "Select the option used to access the GitHub server to connect and perform the automated operations.",
+        "options": [
+          "GitHub Cloud",
+          "GitHub Enterprise"
+        ],
+        "onchange": {
+          "GitHub Cloud": [
+            {
+              "title": "Server API URL",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "server_url",
+              "value": "https://api.github.com",
+              "description": "Specify the URL of the GitHub server to connect and perform automated operations.",
+              "tooltip": "Specify the URL of the GitHub server to connect and perform automated operations"
+            }
+          ],
+          "GitHub Enterprise": [
+            {
+              "title": "Server API URL",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "type": "text",
+              "name": "server_url",
+              "description": "Specify the URL of the GitHub server to connect and perform automated operations.",
+              "tooltip": "Specify the URL of the GitHub server to connect and perform automated operations"
+            }
+          ]
+        }
       },
       {
         "title": "Username",
@@ -53,17 +83,6 @@
         "editable": true,
         "visible": true,
         "value": true
-      },
-      {
-        "title": "Clone URL",
-        "required": false,
-        "editable": true,
-        "visible": true,
-        "type": "text",
-        "name": "clone_url",
-        "value": "https://codeload.github.com",
-        "description": "This field contains the Codeload URL for fast push and pull operations. NOTE: Do not edit the value in this field.",
-        "tooltip": "Specify the clone URL of the GitHub server to connect and perform cloned operation. NOTE: Do not edit the value in this field."
       }
     ]
   },

--- a/github/operations.py
+++ b/github/operations.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2024 Fortinet Inc
+Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
 
@@ -35,6 +35,7 @@ FileMetadata = namedtuple('FileMetadata', ['filename',
 class GitHub(object):
     def __init__(self, config):
         self.server_url = config.get('server_url')
+        github_type = config.get('github_account')
         if not self.server_url.startswith('https://'):
             self.server_url = 'https://' + self.server_url
         if not self.server_url.endswith('/'):
@@ -42,7 +43,11 @@ class GitHub(object):
         self.git_username = config.get('username')
         self.password = config.get('password')
         self.verify_ssl = config.get('verify_ssl')
-        self.clone_url = config.get('clone_url')
+        if github_type == "GitHub Cloud":
+            self.clone_url = "https://codeload.github.com"
+        elif github_type == "GitHub Enterprise":
+            self.clone_url = f'{self.server_url}_codeload'
+            self.server_url += 'api/v3/'
 
     def make_request(self, endpoint=None, method='GET', data=None, params=None, owner=None, org=None):
         try:
@@ -249,10 +254,11 @@ def fetch_upstream(config, params, *args, **kwargs):
 
 def clone_repository(config, params, *args, **kwargs):
     try:
+        github = GitHub(config)
         env = kwargs.get('env', {})
         url = "https://{0}:{1}@{2}/{3}/{4}/zip/refs/heads/{5}".format(config.get('username'),
                                                                       config.get('password'),
-                                                                      config.get('clone_url', '').split('//')[-1],
+                                                                      github.clone_url.split('//')[-1],
                                                                       params.get('org') if params.get(
                                                                           'repo_type') == "Organization" else params.get(
                                                                           'owner'),
@@ -264,8 +270,6 @@ def clone_repository(config, params, *args, **kwargs):
         zip_file = '/tmp/github-{0}-{1}.zip'.format(params.get('name'), datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f'))
         response = requests.request("GET", url, headers=headers, data={}, verify=config.get('verify_ssl'))
         if not response.ok:
-            if config.get('clone_url') != 'https://codeload.github.com':
-                raise ConnectorError("Invalid clone URL provided in the connector configuration.")
             logger.error("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code, response.text if response.text else response.content))
             raise ConnectorError("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code, response.text if response.text else response.content))
         with open(zip_file, "wb") as zipFile:
@@ -351,7 +355,8 @@ def update_clone_repository(config, params, *args, **kwargs):
 
 def push_repository(config, params, *args, **kwargs):
     token = config.get('password')
-    g = Github(token)
+    github = GitHub(config)
+    g = Github(token, base_url=github.server_url.strip("/"), verify=False)
     if params.get('repo_type') == 'Organization':
         repo = g.get_organization(params.get('org')).get_repo(params.get('name'))
     else:

--- a/github/operations.py
+++ b/github/operations.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from github import Github
 from github import InputGitTreeElement
 import shutil
-from .constants import CLONE_ACCEPT_HEADER
+from .constants import CLONE_ACCEPT_HEADER, CLONE_URL
 from base64 import b64encode
 from datetime import datetime
 from connectors.core.connector import get_logger, ConnectorError
@@ -44,7 +44,7 @@ class GitHub(object):
         self.password = config.get('password')
         self.verify_ssl = config.get('verify_ssl')
         if github_type == "GitHub Cloud":
-            self.clone_url = "https://codeload.github.com"
+            self.clone_url = CLONE_URL
         elif github_type == "GitHub Enterprise":
             self.clone_url = f'{self.server_url}_codeload'
             self.server_url += 'api/v3/'
@@ -197,7 +197,7 @@ def list_repository_collaborator(config, params, *args, **kwargs):
     params['affiliation'] = params.get('affiliation', '').lower()
     params['permission'] = params.get('permission', '').lower()
     query_params = {k: v for k, v in params.items() if
-               v is not None and v != '' and v != {} and v != [] and k not in ['owner', 'repo', 'org']}
+                    v is not None and v != '' and v != {} and v != [] and k not in ['owner', 'repo', 'org']}
     return github.make_request(params=query_params, org=params.get('org'), owner=params.get('owner'),
                                endpoint='{0}/collaborators'.format(params.get('repo')))
 
@@ -270,8 +270,10 @@ def clone_repository(config, params, *args, **kwargs):
         zip_file = '/tmp/github-{0}-{1}.zip'.format(params.get('name'), datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f'))
         response = requests.request("GET", url, headers=headers, data={}, verify=config.get('verify_ssl'))
         if not response.ok:
-            logger.error("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code, response.text if response.text else response.content))
-            raise ConnectorError("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code, response.text if response.text else response.content))
+            logger.error("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code,
+                                                                                       response.text if response.text else response.content))
+            raise ConnectorError("Error occurred: {{\"status_code\": {0}, Error: {1}}}".format(response.status_code,
+                                                                                               response.text if response.text else response.content))
         with open(zip_file, "wb") as zipFile:
             zipFile.write(response.content)
         if params.get('clone_zip') is True:
@@ -356,7 +358,7 @@ def update_clone_repository(config, params, *args, **kwargs):
 def push_repository(config, params, *args, **kwargs):
     token = config.get('password')
     github = GitHub(config)
-    g = Github(token, base_url=github.server_url.strip("/"), verify=False)
+    g = Github(token, base_url=github.server_url.strip("/"), verify=github.verify_ssl)
     if params.get('repo_type') == 'Organization':
         repo = g.get_organization(params.get('org')).get_repo(params.get('name'))
     else:
@@ -653,7 +655,8 @@ def delete_file_from_repository(config, params, *args, **kwargs):
         "branch": params.get('branch') if params.get('branch') else 'main'
     }
     endpoint = '{0}/contents/{1}'.format(params.get('name'), params.get('path'))
-    response = github.make_request(method='DELETE', endpoint=endpoint, org=params.get('org'), owner=params.get('owner'), data=json.dumps(payload))
+    response = github.make_request(method='DELETE', endpoint=endpoint, org=params.get('org'), owner=params.get('owner'),
+                                   data=json.dumps(payload))
     return response
 
 

--- a/github/release_notes.md
+++ b/github/release_notes.md
@@ -1,9 +1,5 @@
 #### What's Improved
-- Added following new actions:
-  - Get File
-  - Delete File
-  - Search Code
-- Updated output schema of `Push Changes` action.
-- Fixed an issue where the action Clone Repository was failing with the following error: 
-   > `File is not a zip file`
-- Fixed an issue where the actions Update Remote Repository and Push Changes ignored the deleted files.
+
+- Integrated support for `GitHub Enterprise` account.
+- Discarded the `Clone URL` parameter from the configuration, with handling now implemented directly in the code for both `GitHub Cloud` and `GitHub Enterprise`.
+- Moved the `Server API URL` parameter to the new `GitHub Account` parameter in the configuration to support both `GitHub Cloud` and `GitHub Enterprise` accounts.


### PR DESCRIPTION
#### PMDB: N/A

#### Descriptions:

- Integrated support for `GitHub Enterprise` account.
- Discarded the `Clone URL` parameter from the configuration, with handling now implemented directly in the code for both `GitHub Cloud` and `GitHub Enterprise`.
- Moved the `Server API URL` parameter to the new `GitHub Account` parameter in the configuration to support both `GitHub Cloud` and `GitHub Enterprise` accounts.

#### UTCs:

- [x] Verified `Clone Repository` action using both `GitHub Cloud` and `GitHub Enterprise` accounts.
- [x] Verified CICD using both `GitHub Cloud` and `GitHub Enterprise` accounts.
- [x] Verified playbook's and it's tags.
- [x] Verified actions.